### PR TITLE
Visual identity

### DIFF
--- a/audio-list.html
+++ b/audio-list.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/book-groups-list.html
+++ b/book-groups-list.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/content-audio.html
+++ b/content-audio.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/content-borrowbox.html
+++ b/content-borrowbox.html
@@ -50,7 +50,7 @@
     <div class="container-fluid page-wrap">
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -96,7 +96,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/content-expando.html
+++ b/content-expando.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/content-opac-landing.html
+++ b/content-opac-landing.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/content-starter.html
+++ b/content-starter.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/content-tables.html
+++ b/content-tables.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/content-video-embed.html
+++ b/content-video-embed.html
@@ -50,7 +50,7 @@
     <div class="container-fluid page-wrap">
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -96,7 +96,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/content.html
+++ b/content.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/css/style.css
+++ b/css/style.css
@@ -369,7 +369,7 @@ h1, h2, h3, h4, h5, h6,
     color: #777777; }
 
 h1, .h1 {
-  font-family: montserrat, Arial, Helvetica, sans-serif; }
+  font-family: montserrat, "Arial Black", Helvetica, sans-serif; }
 
 h1, .h1,
 h2, .h2,

--- a/css/style.css
+++ b/css/style.css
@@ -5434,13 +5434,16 @@ footer {
     footer .ssc .logo {
       text-align: right; }
   footer .ssc .logo svg {
-    height: 80px; }
+    height: 80px;
+    width: calc(107.15 / 46.33 * 80px); }
 
 header {
   padding: 20px 0; }
 
 svg.logo {
-  padding: 0.5em 0 1.5em; }
+  padding: 0.5em 0 1.5em;
+  width: 100%;
+  max-height: 77px; }
 
 .ssc-link {
   font-size: 16px;

--- a/event-detail.html
+++ b/event-detail.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/event-list-sort.html
+++ b/event-list-sort.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/events-list.html
+++ b/events-list.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/form.html
+++ b/form.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/json-google.html
+++ b/json-google.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/kit/components/_header.htm
+++ b/kit/components/_header.htm
@@ -1,5 +1,5 @@
 <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -45,7 +45,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/listview.html
+++ b/listview.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/new-items.html
+++ b/new-items.html
@@ -69,7 +69,7 @@
 
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -115,7 +115,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/owl-carousel-instructions.html
+++ b/owl-carousel-instructions.html
@@ -50,7 +50,7 @@
     <div class="container-fluid page-wrap">
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -96,7 +96,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/owl-carousel-json.html
+++ b/owl-carousel-json.html
@@ -51,7 +51,7 @@
     <div class="container-fluid page-wrap">
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -97,7 +97,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/owl-carousel.html
+++ b/owl-carousel.html
@@ -50,7 +50,7 @@
     <div class="container-fluid page-wrap">
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -96,7 +96,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/property-list.html
+++ b/property-list.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/property.html
+++ b/property.html
@@ -50,7 +50,7 @@
     <div class="container-fluid page-wrap">
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -96,7 +96,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/recurring-event.html
+++ b/recurring-event.html
@@ -57,7 +57,7 @@
       </div>
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -103,7 +103,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/resource-detail.html
+++ b/resource-detail.html
@@ -50,7 +50,7 @@
     <div class="container-fluid page-wrap">
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -96,7 +96,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/resources-list.html
+++ b/resources-list.html
@@ -50,7 +50,7 @@
     <div class="container-fluid page-wrap">
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -96,7 +96,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/rss-list.html
+++ b/rss-list.html
@@ -50,7 +50,7 @@
     <div class="container-fluid page-wrap">
 
       <header id="banner" class="row banner">
-  <div class="col-sm-6">
+  <div class="col-sm-6 col-lg-5">
     <!-- <p class="ssc-link">A <a href="http://www.sutherlandshire.nsw.gov.au">Sutherland Shire Council</a> Facility</p> -->
     <a class="logo-wrapper" href="http://www.sutherlandshire.nsw.gov.au/community/library">
       <!-- <div class="title-logo">Sutherland Shire Council - Libraries</div> -->
@@ -96,7 +96,7 @@
     </a>
   </div><!-- /column -->
 
-  <div class="col-sm-6 catalog">
+  <div class="col-sm-6 col-lg-7 catalog">
     <div id="catalog-search" class="catalog-search form-inline">
       <div class="form-group">
         <label for="catalog-search-textbox" class="hidden-xs hidden-sm">Search our collection</label>

--- a/sass/bootstrap/_variables.scss
+++ b/sass/bootstrap/_variables.scss
@@ -97,7 +97,7 @@ $line-height-base:        1.428571429 !default; // 20/14
 $line-height-computed:    floor(($font-size-base * $line-height-base)) !default; // ~20px
 
 //** By default, this inherits from the `<body>`.
-$headings-font-family:    montserrat, Arial, Helvetica, sans-serif;
+$headings-font-family:    montserrat, "Arial Black", Helvetica, sans-serif;
 $headings-font-weight:    normal !default;
 $headings-line-height:    1.2 !default;
 $headings-color:          $lightblue;

--- a/sass/components/_footer.scss
+++ b/sass/components/_footer.scss
@@ -24,5 +24,6 @@ footer {
 
   .ssc .logo svg {
     height: 80px;
+    width: calc(107.15 / 46.33 * 80px); //keep aspect ratio in IE10/11
   }
 }

--- a/sass/components/_header.scss
+++ b/sass/components/_header.scss
@@ -4,6 +4,10 @@ header {
 
 svg.logo {
     padding: 0.5em 0 1.5em;
+    width: 100%;
+    max-height: 77px; //magic number, required for IE10, 11
+    // to get a better result than this requires a containing div with an
+    // aspect ratio padding-bottom hack. See https://css-tricks.com/scale-svg/
 }
 
 .ssc-link {


### PR DESCRIPTION
fixes (sort of) the default 150px height for SVGs in IE11 where an explicit width/height is not declared. for more detail see https://css-tricks.com/scale-svg/