### PR TITLE
added campaign tags to blog post template

### DIFF
--- a/kit/owl-carousel-json.kit
+++ b/kit/owl-carousel-json.kit
@@ -25,7 +25,7 @@
             <div class="book-detail sr-only">
               <h4>{{gsx$title.$t}}</h4>
               <p>{{{gsx$review.$t}}}</p>
-              <p><a class="btn btn-success" target="_blank" href="http://encore.sutherlandshire.nsw.gov.au/iii/encore/record/C__R{{gsx$bib.$t}}">Get it!</a></p>
+              <p><a class="btn btn-success" target="_blank" href="http://encore.sutherlandshire.nsw.gov.au/iii/encore/record/C__R{{gsx$bib.$t}}?utm_source=blog&utm_medium=online&utm_campaign=[post-title]">Get it!</a></p>
             </div>
           </article>
         {{/each}}

--- a/owl-carousel-json.html
+++ b/owl-carousel-json.html
@@ -213,7 +213,7 @@
             <div class="book-detail sr-only">
               <h4>{{gsx$title.$t}}</h4>
               <p>{{{gsx$review.$t}}}</p>
-              <p><a class="btn btn-success" target="_blank" href="http://encore.sutherlandshire.nsw.gov.au/iii/encore/record/C__R{{gsx$bib.$t}}">Get it!</a></p>
+              <p><a class="btn btn-success" target="_blank" href="http://encore.sutherlandshire.nsw.gov.au/iii/encore/record/C__R{{gsx$bib.$t}}?utm_source=blog&utm_medium=online&utm_campaign=[post-title]">Get it!</a></p>
             </div>
           </article>
         {{/each}}


### PR DESCRIPTION
added google analytics campaign tags to the handlebars template for book list blog posts. This will allow us to see in the Google analytics for the library catalogue when the  traffic source is a blog post